### PR TITLE
fix: repair workflow actionlint failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,29 +34,6 @@ jobs:
           - ubuntu-2004
         suite:
           - default
-        exclude:
-          - os: amazonlinux-2
-            suite: pkg-name
-          - os: debian-10
-            suite: pkg-name
-          - os: debian-11
-            suite: pkg-name
-          - os: almalinux-8
-            suite: pkg-name
-          - os: centos-stream-8
-            suite: pkg-name
-          - os: rockylinux-8
-            suite: pkg-name
-          - os: fedora-latest
-            suite: pkg-name
-          - os: fedora-latest
-            suite: mod-php
-          - os: ubuntu-1804
-            suite: pkg-name
-          - os: ubuntu-2004
-            suite: pkg-name
-          - os: opensuse-leap-15
-            suite: pkg-name
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## Summary

* Fix GitHub Actions workflow syntax/static lint failures reported by actionlint.
* Remove invalid debug output, stale matrix entries, duplicate matrix values, or conflict markers as applicable.

## Verification

* `actionlint -no-color -oneline`
* `yq e '.' .github/workflows/*.yml`
