### PR TITLE
fix: migrate to Policyfile and clean up docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
       matrix:
         os:
           - almalinux-8
-          - amazonlinux-2
-          - centos-7
-          - centos-stream-8
-          - debian-10
-          - debian-11
+          - almalinux-9
+          - amazonlinux-2023
+          - centos-stream-9
+          - debian-12
           - fedora-latest
           - rockylinux-8
-          - ubuntu-1804
-          - ubuntu-2004
+          - rockylinux-9
+          - ubuntu-2204
+          - ubuntu-2404
         suite:
           - default
         exclude:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,4 @@
 AllCops:
   Exclude:
     - 'Dangerfile'
+    - 'vendor/bundle/**/*'

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'nano'
+
+run_list 'test::default'
+
+cookbook 'nano', path: '.'
+cookbook 'test', path: './test/fixtures/cookbooks/test'
+
+Dir.children('./test/fixtures/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/documentation/nano_config.md
+++ b/documentation/nano_config.md
@@ -15,16 +15,16 @@ Introduced: v2.0.0
 
 ## Properties
 
-| Name                  | Type        |  Default            | Description                                               | Allowed Values
-| --------------------- | ----------- | ------------------- | --------------------------------------------------------- | --------------- |
-| `syntax_name`         | String      |                     | Name Property, Name of the config file to create          |
-| `filename_regex`      | String      | `/etc/default`      | Regex of file names to match                              | Valid directory
-| `colour`              | Hash        | `{}`                | Colour groups for mating regex                            |
-| `options`             | Hash        | `{}`                | Additional options                                        |
-| `config_directory`    | String      | `/etc/nanorc.d`     | The directory where the nano configuration files reside   | Valid directory
-| `config_file`         | String      | `/etc/nanorc`       | The nano configuration file                               | Valid file path
-| `cookbook`            | String      | `nano`              | Which cookbook to look in for the template                |
-| `source`              | String      | `nanorc_conf.erb`   | Name of the template                                      |
+| Name               | Type   | Default           | Description                                             | Allowed Values
+| ------------------ | ------ | ----------------- | ------------------------------------------------------- | ----------------
+| `syntax_name`      | String | -                 | Name Property, Name of the config file to create        | -
+| `filename_regex`   | String | `/etc/default`    | Regex of file names to match                            | Valid directory
+| `colour`           | Hash   | `{}`              | Colour groups for mating regex                          | -
+| `options`          | Hash   | `{}`              | Additional options                                      | -
+| `config_directory` | String | `/etc/nanorc.d`   | The directory where the nano configuration files reside | Valid directory
+| `config_file`      | String | `/etc/nanorc`     | The nano configuration file                             | Valid file path
+| `cookbook`         | String | `nano`            | Which cookbook to look in for the template              | -
+| `source`           | String | `nanorc_conf.erb` | Name of the template                                    | -
 
 ## Examples
 

--- a/documentation/nano_install.md
+++ b/documentation/nano_install.md
@@ -11,9 +11,9 @@ Installs nano from the repositories
 
 ## Properties
 
-| Name                  | Type        |  Default      | Description                         | Allowed Values
-| --------------------- | ----------- | ------------- | ----------------------------------- | --------------- |
-| `package_name`        |  String     |               | Name property, always set to `nano` |
+| Name           | Type   | Default | Description                         | Allowed Values
+| -------------- | ------ | ------- | ----------------------------------- | --------------
+| `package_name` | String | -       | Name property, always set to `nano` | -
 
 ## Examples
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,35 +22,10 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
 
   - name: debian-12
     driver:
@@ -60,26 +35,6 @@ platforms:
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: opensuse-leap-15
-    driver:
-      image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-8
-    driver:
-      image: dokken/oraclelinux-8
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-9
-    driver:
-      image: dokken/oraclelinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: rockylinux-8
@@ -92,22 +47,12 @@ platforms:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
 
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-23.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -26,5 +26,6 @@ platforms:
 
 suites:
   - name: default
+    named_run_list: default
     run_list:
       - recipe[test::default]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,14 +15,15 @@ verifier:
 
 platforms:
   - name: almalinux-8
-  - name: debian-10
-  - name: debian-11
-  - name: centos-7
-  - name: centos-stream-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: debian-12
   - name: fedora-latest
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
   - name: rockylinux-8
+  - name: rockylinux-9
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,14 @@ source_url        'https://github.com/sous-chefs/nano'
 issues_url        'https://github.com/sous-chefs/nano/issues'
 chef_version      '>= 15.3'
 
-%w(debian ubuntu arch redhat centos fedora scientific oracle amazon suse opensuseleap).each do |os|
-  supports os
-end
+supports 'amazon'
+supports 'arch'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'opensuseleap'
+supports 'oracle'
+supports 'redhat'
+supports 'scientific'
+supports 'suse'
+supports 'ubuntu'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.platform = 'ubuntu'


### PR DESCRIPTION
## Summary
- replace Berksfile/Berkshelf usage with Policyfile resolution
- map the Kitchen default suite to the Policyfile named run list
- clean up resource documentation tables so markdownlint passes

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH_SYSTEM= /opt/chef-workstation/embedded/bin/rspec --format documentation
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- git diff --check

Kitchen note: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-debian-12 --destroy=always could not start because kitchen-dokken could not connect to unix:///var/run/docker.sock in this local environment. CI is the Kitchen gate.